### PR TITLE
Python unversioned

### DIFF
--- a/packages/rpm
+++ b/packages/rpm
@@ -13,9 +13,9 @@ make
 mock
 podman
 python38
-python3-ansible-lint
-python3-argcomplete
-python3-devel
+python-ansible-lint
+python-argcomplete
+python-devel
 redhat-rpm-config
 rpm-build
 rpmdevtools

--- a/packages/rpm
+++ b/packages/rpm
@@ -12,7 +12,6 @@ langpacks-en
 make
 mock
 podman
-python38
 python-ansible-lint
 python-argcomplete
 python-devel


### PR DESCRIPTION
Remove explicit Python 3 versioning of DNF Python packages.
Remove Python 3.8 package, since it's not useful without matching PIP and currently doesn't add any value by being present.